### PR TITLE
Add GitHub App uninstall action

### DIFF
--- a/ruoyi-ui/src/components/RuoYi/Git/index.vue
+++ b/ruoyi-ui/src/components/RuoYi/Git/index.vue
@@ -1,7 +1,13 @@
 <template>
-  <div>
-    <svg-icon icon-class="github" @click="goto" />
-  </div>
+  <el-dropdown trigger="click" @command="handleCommand">
+    <span class="github-app-actions">
+      <svg-icon icon-class="github" />
+    </span>
+    <el-dropdown-menu slot="dropdown">
+      <el-dropdown-item command="install">Install GitHub App</el-dropdown-item>
+      <el-dropdown-item command="uninstall">Uninstall GitHub App</el-dropdown-item>
+    </el-dropdown-menu>
+  </el-dropdown>
 </template>
 
 <script>
@@ -9,13 +15,29 @@ export default {
   name: 'RuoYiGit',
   data() {
     return {
-      url: 'https://gitee.com/y_project/RuoYi-Vue'
+      installUrl: process.env.VUE_APP_GITHUB_APP_INSTALL_URL
+        || 'https://github.com/apps',
+      uninstallUrl: process.env.VUE_APP_GITHUB_APP_UNINSTALL_URL
+        || 'https://github.com/settings/installations'
     }
   },
   methods: {
-    goto() {
-      window.open(this.url)
+    handleCommand(command) {
+      const urlMap = {
+        install: this.installUrl,
+        uninstall: this.uninstallUrl
+      }
+      window.open(urlMap[command], '_blank')
     }
   }
 }
 </script>
+
+<style scoped>
+.github-app-actions {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## Summary
- Replace the GitHub header icon action with a dropdown for GitHub App management.
- Add both install and uninstall actions, with environment-configurable URLs and safe defaults.

## Verification
- git diff --check
- npm --prefix ruoyi-ui run lint -- --quiet (does not run in this clone because dependencies are not installed and eslint is unavailable)

fixes #16
agentpay-wallet: 0xe2e86bdb8753c24032f2ad42b4c1bd9748385a7d